### PR TITLE
Fix node16 deprecation notice

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,5 +31,5 @@ inputs:
         required: false
         default: ""
 runs:
-    using: 'node16'
+    using: 'node20'
     main: 'out/index.js'


### PR DESCRIPTION
#### Description
Use node20 instead of node16.

#### Reason
Github is deprecating the use of node16 for Github Actions. [Link to Blog](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
 
